### PR TITLE
Feature #159028457 Serving the Non-persistent Endpoints 

### DIFF
--- a/app/main/controller/entry_controller.py
+++ b/app/main/controller/entry_controller.py
@@ -3,7 +3,7 @@ from flask import request
 from flask_restplus import Resource
 
 from ..utils.dto import EntryDto
-from ..service.entry_service import add_entry, get_all_entries, get_one_entry
+from ..service.entry_service import add_entry, get_all_entries, get_one_entry, modify_entry
 
 api = EntryDto.api
 entry = EntryDto.entry
@@ -44,3 +44,10 @@ class Entry(Resource):
         FETCH an entry
         """
         return get_one_entry(entry_id)
+
+    def put(self, entry_id):
+        """
+        MODIFY an entry
+        """
+        data = request.json
+        return modify_entry(entry_id, data)

--- a/app/main/controller/entry_controller.py
+++ b/app/main/controller/entry_controller.py
@@ -3,7 +3,7 @@ from flask import request
 from flask_restplus import Resource
 
 from ..utils.dto import EntryDto
-from ..service.entry_service import add_entry
+from ..service.entry_service import add_entry, get_all_entries
 
 api = EntryDto.api
 entry = EntryDto.entry
@@ -21,3 +21,11 @@ class Entries(Resource):
         """
         data = request.json
         return add_entry(data=data)
+
+    @api.marshal_with(entry, envelope='data')
+    @api.response(200, 'Successfully fetched entries!')
+    def get(self):
+        """
+        FETCH entries
+        """
+        return get_all_entries()

--- a/app/main/controller/entry_controller.py
+++ b/app/main/controller/entry_controller.py
@@ -3,7 +3,7 @@ from flask import request
 from flask_restplus import Resource
 
 from ..utils.dto import EntryDto
-from ..service.entry_service import add_entry, get_all_entries
+from ..service.entry_service import add_entry, get_all_entries, get_one_entry
 
 api = EntryDto.api
 entry = EntryDto.entry
@@ -29,3 +29,18 @@ class Entries(Resource):
         FETCH entries
         """
         return get_all_entries()
+
+@api.route('/entries/<int:entry_id>')
+@api.param('entry_id' , 'The identifier for the entry')
+@api.response(404, 'Entry not found!')
+class Entry(Resource):
+    """
+    The Single Entry Resource for the API
+    """
+    @api.marshal_with(entry, envelope='entry')
+    @api.response(200, 'Successfully fetched an entry!')
+    def get(self, entry_id):
+        """
+        FETCH an entry
+        """
+        return get_one_entry(entry_id)

--- a/app/main/model/entries.py
+++ b/app/main/model/entries.py
@@ -23,11 +23,11 @@ class Entry(object):
         : return entry
         """
         return {
-            'id' :  self.id,
+            'message' :  'Entry Added!',
             'title' :  self.title,
             'content' : self.content,
-            'posted on' : self.date_created
-        }
+            'posted on' : str(self.date_created)
+            }
 
 mock_db = {
     'entries': [] # Entries table

--- a/app/main/service/entry_service.py
+++ b/app/main/service/entry_service.py
@@ -36,3 +36,18 @@ def get_one_entry(entry_id):
     entry = MockDB.get_entry_by_id(entry_id)
     
     return entry, 200
+
+def modify_entry(entry_id, data):
+    entry = MockDB.get_entry_by_id(entry_id)
+    entry_data = entry.display_entry_holder()
+
+    entry_data['title'] = data['title']
+    entry_data['content'] = data['content']
+
+    return entry_data, 200
+
+    
+
+    
+
+

--- a/app/main/service/entry_service.py
+++ b/app/main/service/entry_service.py
@@ -27,4 +27,12 @@ def get_all_entries():
     FETCH all entries
     """
     entries = [entry for entry in MockDB.entries]
-    return entries,200
+    return entries, 200
+
+def get_one_entry(entry_id):
+    """
+    FETCH an entry
+    """
+    entry = MockDB.get_entry_by_id(entry_id)
+    
+    return entry, 200

--- a/app/main/service/entry_service.py
+++ b/app/main/service/entry_service.py
@@ -13,17 +13,18 @@ def add_entry(data):
     title = data['title']
     content = data['content']
 
+
     new_entry = Entry(title=title,
                         content=content)
-
+    
     MockDB.entries.append(new_entry) 
-    return {
-        'status': 'Created!',
-        'id' : new_entry.id,
-        'title' : new_entry.title,
-        'content': new_entry.content,
-        'posted on' : str(datetime.datetime.utcnow())
-    } , 201  
+    
+    return new_entry.display_entry_holder(), 201  
 
   
-
+def get_all_entries():
+    """
+    FETCH all entries
+    """
+    entries = [entry for entry in MockDB.entries]
+    return entries,200

--- a/app/main/utils/dto.py
+++ b/app/main/utils/dto.py
@@ -10,3 +10,4 @@ class EntryDto(object):
         'title': fields.String(required=True, description='The title for the journal entry'),
         'content': fields.String(required=True, description='The content for the journal entry')
     })
+    


### PR DESCRIPTION
### What does the PR do?
Updates the repo with the `GET api/v1/entries`  to **FETCH** all **ENTRIES**, `GET api/v1/entries/<entry_id>` to **FETCH** an **ENTRY** and the `PUT api/v1/entries/<entry_id> ` to **MODIFY** an **ENTRY** 
 
The code for the endpoints is on the `ft-get-entries` , `ft-get-one-entry` , and `ft-modify-entry`branches respectively  

### Description of tasks completed
1. GET api/v1/entries endpoint
2. Tests for the GET api/v1/entries endpoint 
3. GET api/v1/entries/<entry_id> endpoint
4. Tests for the GET api/v1/entries/<entry_id> endpoint 
5. PUT api/v1/entries/<entry_id> endpoint
6. Tests for the PUT api/v1/entries/<entry_id> endpoint

### Manual Testing 
1. Clone the repo
2. Run `python manage.py test` to run tests 
3. Run `python manage.py run` to run the application
4. Navigate to the http://127.0.0.1:5000/api/v1/entries endpoint on the address bar 

### Pivotal Tracker Story
#159028388#159028290#159028457 
### Notes
>Please feel free to leave a comment on the PR and on slack 

